### PR TITLE
Allow use on streams; Option for case sensitive headers

### DIFF
--- a/http-parser.js
+++ b/http-parser.js
@@ -204,8 +204,8 @@ HTTPParser.prototype.BODY_CHUNK = function () {
 
 HTTPParser.prototype.BODY_RAW = function () {
   var length = this.end - this.offset;
+  this.onBody(this.chunk, this.offset, length);
   this.offset += length;
-  this.body_bytes -= length;
 };
 
 HTTPParser.prototype.BODY_SIZED = function () {


### PR DESCRIPTION
I'm using this to parse a stream of response messages, so I've added Content-Length accounting to know when we reach the end of a non-chunked message.

The second commit adds a preserCase option to avoid lower casing header names.
