### PR TITLE
package.json: use `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git://github.com/creationix/http-parser-js.git"
   },
+  "files": [
+    "http-parser.js"
+  ],
   "keywords": [
     "http"
   ],


### PR DESCRIPTION
See [documentation](https://docs.npmjs.com/files/package.json#files).

This makes the install faster, because the `tests` folder (391KB) will no longer be installed.