### PR TITLE
Added unit test for the default and the "increased" header size

### DIFF
--- a/tests/parallel/test-http-client-max-header-size_default.js
+++ b/tests/parallel/test-http-client-max-header-size_default.js
@@ -1,0 +1,40 @@
+'use strict';
+require('../common');
+
+var assert = require('assert');
+var http = require('http');
+
+var s = "x".repeat(1024 * 1024);
+
+var header = {
+  'x-custom-header': s,
+  'Connection':'keep-alive',
+  'Content-Length': 0,
+  'Content-Type':'application/json; charset=UTF-8'
+};
+
+var server = http.createServer(function(req, res) {
+  // code should not get here
+  assert(false);
+
+  res.end();
+
+  server.close();
+});
+
+server.listen(0, function() {
+  var options = {
+    port: server.address().port,
+    method: 'GET',
+    headers: header
+  };
+
+  var r = http.request(options);
+  r.on('error', function(err) {
+    // Handle error, the code will get here
+    assert(true);
+
+    server.close();
+  });
+  r.end();
+});

--- a/tests/parallel/test-http-client-max-header-size_increased.js
+++ b/tests/parallel/test-http-client-max-header-size_increased.js
@@ -1,0 +1,39 @@
+'use strict';
+require('../common');
+
+// set max header size
+require('../../../http-parser-js').HTTPParser.maxHeaderSize = 1024 * 1024; // 1MB instead of 80kb
+
+var assert = require('assert');
+var http = require('http');
+
+var s = "x".repeat(1024 * 1024);
+
+var header = {
+  'x-custom-header': s,
+  'Connection':'keep-alive',
+  'Content-Length': 0,
+  'Content-Type':'application/json; charset=UTF-8'
+};
+
+var server = http.createServer(function(req, res) {
+  // code wouldn't come here if an error was thrown
+  assert(true);
+  res.end();
+
+  server.close();
+});
+
+server.listen(0, function() {
+  var options = {
+    port: server.address().port,
+    method: 'GET',
+    headers: header
+  };
+
+  var r = http.request(options);
+  r.on('error', function(err) {
+    assert(false);
+  });
+  r.end();
+});


### PR DESCRIPTION
See https://github.com/creationix/http-parser-js/pull/29.
I've added two unit tests; one for the default maxHeaderSize (which should fail), and one test for the increased header size.