### PR TITLE
getAsyncId() return 0 instead of false

### DIFF
--- a/http-parser.js
+++ b/http-parser.js
@@ -83,7 +83,7 @@ HTTPParser.prototype.close =
 HTTPParser.prototype.pause =
 HTTPParser.prototype.resume = function () {};
 HTTPParser.prototype._compatMode0_11 = false;
-HTTPParser.prototype.getAsyncId = function() { return false; };
+HTTPParser.prototype.getAsyncId = function() { return 0; };
 
 var headerState = {
   REQUEST_LINE: true,


### PR DESCRIPTION
This fixes #40, crashing on Node v8.5.0 which has more strict checks on "async ids".