### PR TITLE
Fix handling of skipBody=0 return from Node's onHeadersComplete()

### DIFF
--- a/http-parser.js
+++ b/http-parser.js
@@ -341,6 +341,8 @@ HTTPParser.prototype.HEADER = function () {
       this.state = 'BODY_CHUNKHEAD';
     } else if (skipBody || this.body_bytes === 0) {
       this.nextRequest();
+      // For older versions of node (v6.x and older?), that return skipBody=1 or skipBody=true,
+      //   need this "return true;" if it's an upgrade request.
       return info.upgrade;
     } else if (this.body_bytes === null) {
       this.state = 'BODY_RAW';

--- a/http-parser.js
+++ b/http-parser.js
@@ -334,7 +334,8 @@ HTTPParser.prototype.HEADER = function () {
           info.versionMinor, info.headers, info.method, info.url, info.statusCode,
           info.statusMessage, info.upgrade, info.shouldKeepAlive));
     }
-    if (skipBody === 2) { // May also need || compatMode0_12 && info.upgrade?  Probably too old to matter now
+    // Were there other version between 0.12 and when skipBody==2 logic was added?
+    if (skipBody === 2 || (this._compatMode0_11 || compatMode0_12) && info.upgrade) {
       this.nextRequest();
       return true;
     } else if (this.isChunked && !skipBody) {
@@ -422,6 +423,7 @@ HTTPParser.prototype.BODY_SIZED = function () {
     set: function (to) {
       // hack for backward compatibility
       this._compatMode0_11 = true;
+      method_connect = 'CONNECT';
       return (this[k] = to);
     }
   });

--- a/http-parser.js
+++ b/http-parser.js
@@ -334,14 +334,14 @@ HTTPParser.prototype.HEADER = function () {
           info.versionMinor, info.headers, info.method, info.url, info.statusCode,
           info.statusMessage, info.upgrade, info.shouldKeepAlive));
     }
-    // Were there other version between 0.12 and when skipBody==2 logic was added?
-    if (skipBody === 2 || (this._compatMode0_11 || compatMode0_12) && info.upgrade) {
+    if (skipBody === 2) {
       this.nextRequest();
       return true;
     } else if (this.isChunked && !skipBody) {
       this.state = 'BODY_CHUNKHEAD';
     } else if (skipBody || this.body_bytes === 0) {
       this.nextRequest();
+      return info.upgrade;
     } else if (this.body_bytes === null) {
       this.state = 'BODY_RAW';
     } else {


### PR DESCRIPTION
We should not skip the body (even if we told Node it was an upgrade request) if it tells us not to.
Also update detection of upgrade request/response logic to match latest in Node's http-parser.