### PR TITLE
Create 2 GitHub action runners to run tests

### DIFF
--- a/.github/workflows/node-v12.yaml
+++ b/.github/workflows/node-v12.yaml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# NOTE: This action runs the testv12 test suite.
+
+name: Node-v12
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm run testv12

--- a/.github/workflows/node-v12.yaml
+++ b/.github/workflows/node-v12.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# NOTE: This action runs the normal test suite.
+
+name: Node
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [6.x, 8.x, 10.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
## Changes:

- Creates 2 new GitHub Action Node.js test runners

## Context:

Travis CI is moving to a `.com` domain.
You no longer get free tests for public repositories.
You therefore might want to migrate away from Travis CI and to GitHub Actions.
GitHub actions are free for public repositories.

`npm test` runs on: Node 6, 8, 10 and 14.
`npm run testv12` runs on Node 12.

Tests are all passing now.

After you have reviewed and merged this PR you can remove the Travis CI config file, if you want.