### PR TITLE
Add CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Node](https://github.com/creationix/http-parser-js/workflows/Node/badge.svg)
+![Node-v12](https://github.com/creationix/http-parser-js/workflows/Node-v12/badge.svg)
+
 # HTTP Parser
 
 This library parses HTTP protocol for requests and responses.  It was created to replace `http_parser.c` since calling C++ function from JS is really slow in V8.  However, it is now primarily useful in having a more flexible/tolerant HTTP parser when dealing with legacy services that do not meet the strict HTTP parsing rules Node's parser follows.


### PR DESCRIPTION
## Changes:

- Add CI status badges to README

## Context:

The badges will give everybody who visits the repository a good overview of the tests that are running on this repository, and the status of these tests.

I think it's nice for repositories to show of their passing tests. 😄 

You can see a preview of the badges in the _rich diff_ of this PR.

The `Node-v12` badge looks a little bit wonky unfortunately.
I don't know how to fix the v12 badge for now, I've tried some different things, but none of those worked.

## Documentation:

https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/adding-a-workflow-status-badge