### PR TITLE
Use Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Changes

- Create a `dependabot.yml` config file

## Context

When you merge the current PR, the following will happen:

1. Dependabot will start checking for GitHub Action runner updates from Monday through Friday, not on weekends
2. If an update is found, Dependabot will open a PR
3. Read the changelog, and check if the GitHub Action is a stable release or unstable release
4. If you close the PR, Dependabot will ignore that specific version.
5. If you merge the PR you're up-to-date again.

By default Dependabot adds a label `dependencies` to the PRs it creates.
If you don't want any labels to be created, let me know and I'll turn that off for you.

I can of course turn down the frequency of update checks to a weekly or monthly run.

I hope you like this, if not, feel free to close the PR. 👍 

## Documentation

> Actions are often updated with bug fixes and new features to make automated processes more reliable, faster, and safer. When you enable Dependabot version updates for GitHub Actions, Dependabot will help ensure that references to actions in a repository's workflow.yml file are kept up to date. For each action in the file, Dependabot checks the action's reference (typically a version number or commit identifier associated with the action) against the latest version. If a more recent version of the action is available, Dependabot will send you a pull request that updates the reference in the workflow file to the latest version. 

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot