### PR TITLE
Run tests on Ubuntu 18.04, test node 16

### DIFF
--- a/.github/workflows/node-v12.yaml
+++ b/.github/workflows/node-v12.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false
       matrix:
-        node-version: [6.x, 8.x, 10.x, 14.x]
+        node-version: [6.x, 8.x, 10.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node 16 is now a current release, and it will become a LTS release later on.
You might want to start testing on Node 16 to prepare for when 16 becomes LTS.