### PR TITLE
Use npm cache

### DIFF
--- a/.github/workflows/node-v12.yaml
+++ b/.github/workflows/node-v12.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm install
       - run: npm run build --if-present
       - run: npm run testv12

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
       - run: npm install
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
## Changes:

- Use the new built-in cache functionality that comes with `actions/setup-node@v2.2.0`

## Context:

If you want to use a cache for the npm dependencies, so that (hopefully) the build will be faster, you can merge this PR.

https://github.com/actions/setup-node/releases/tag/v2.2.0