### PR TITLE
Added standalone usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This should now be usable in any node application, it now supports (nearly) ever
 
 Node v12.x renamed the internal http parser, and did not expose it for monkey-patching, so to be able to monkey-patch on Node v12, you must run `node --http-parser=legacy file.js` to opt in to the old, monkey-patchable http_parser binding.
 
+## Standalone usage
+
+While this module is intended to be used as a replacement for the internal Node.js parser, it can be used as a standalone parser. The [`standalone-example.js`](standalone-example.js) demonstrates how to use the somewhat awkward API (coming from compatibility with the Node.js internals) to parse HTTP from raw Buffers.
+
 ## License
 
 MIT.

--- a/standalone-example.js
+++ b/standalone-example.js
@@ -1,0 +1,227 @@
+/*
+  The following is an example of how to use the parser as a standalone module.
+  Both parseRequest and parseResponse can be used to parse a raw HTTP request/response from a Buffer.
+*/
+
+const { deepStrictEqual } = require('assert');
+// Replace the require when using the module from npm.
+//const { HTTPParser } = require('http-parser-js');
+const { HTTPParser } = require('./http-parser.js');
+
+function parseRequest(input) {
+  const parser = new HTTPParser(HTTPParser.REQUEST);
+  let complete = false;
+  let shouldKeepAlive;
+  let upgrade;
+  let method;
+  let url;
+  let versionMajor;
+  let versionMinor;
+  let headers = [];
+  let trailers = [];
+  let bodyChunks = [];
+
+  parser[HTTPParser.kOnHeadersComplete] = function (req) {
+    shouldKeepAlive = req.shouldKeepAlive;
+    upgrade = req.upgrade;
+    method = HTTPParser.methods[req.method];
+    url = req.url;
+    versionMajor = req.versionMajor;
+    versionMinor = req.versionMinor;
+    headers = req.headers;
+  };
+
+  parser[HTTPParser.kOnBody] = function (chunk, offset, length) {
+    bodyChunks.push(chunk.slice(offset, offset + length));
+  };
+
+  // This is actually the event for trailers, go figure.
+  parser[HTTPParser.kOnHeaders] = function (t) {
+    trailers = t;
+  };
+
+  parser[HTTPParser.kOnMessageComplete] = function () {
+    complete = true;
+  };
+
+  parser.execute(input);
+  parser.finish();
+
+  if (!complete) {
+    throw new Error('Could not parse request');
+  }
+
+  let body = Buffer.concat(bodyChunks);
+
+  return {
+    shouldKeepAlive,
+    upgrade,
+    method,
+    url,
+    versionMajor,
+    versionMinor,
+    headers,
+    body,
+    trailers,
+  };
+}
+
+function parseResponse(input) {
+  const parser = new HTTPParser(HTTPParser.RESPONSE);
+  let complete = false;
+  let shouldKeepAlive;
+  let upgrade;
+  let statusCode;
+  let statusMessage;
+  let versionMajor;
+  let versionMinor;
+  let headers = [];
+  let trailers = [];
+  let bodyChunks = [];
+
+  parser[HTTPParser.kOnHeadersComplete] = function (res) {
+    shouldKeepAlive = res.shouldKeepAlive;
+    upgrade = res.upgrade;
+    statusCode = res.statusCode;
+    statusMessage = res.statusMessage;
+    versionMajor = res.versionMajor;
+    versionMinor = res.versionMinor;
+    headers = res.headers;
+  };
+
+  parser[HTTPParser.kOnBody] = function (chunk, offset, length) {
+    bodyChunks.push(chunk.slice(offset, offset + length));
+  };
+
+  // This is actually the event for trailers, go figure.
+  parser[HTTPParser.kOnHeaders] = function (t) {
+    trailers = t;
+  };
+
+  parser[HTTPParser.kOnMessageComplete] = function () {
+    complete = true;
+  };
+
+  parser.execute(input);
+  parser.finish();
+
+  if (!complete) {
+    throw new Error('Could not parse');
+  }
+
+  let body = Buffer.concat(bodyChunks);
+
+  return {
+    shouldKeepAlive,
+    upgrade,
+    statusCode,
+    statusMessage,
+    versionMajor,
+    versionMinor,
+    headers,
+    body,
+    trailers,
+  };
+}
+
+let parsed;
+
+console.log('Example: basic GET request:');
+
+parsed = parseRequest(
+  Buffer.from(`GET / HTTP/1.1
+Host: www.example.com
+
+`)
+);
+
+console.log(parsed);
+
+deepStrictEqual(parsed.shouldKeepAlive, true);
+deepStrictEqual(parsed.upgrade, false);
+deepStrictEqual(parsed.method, 'GET');
+deepStrictEqual(parsed.url, '/');
+deepStrictEqual(parsed.versionMajor, 1);
+deepStrictEqual(parsed.versionMinor, 1);
+deepStrictEqual(parsed.headers, ['Host', 'www.example.com']);
+deepStrictEqual(parsed.body.toString(), '');
+deepStrictEqual(parsed.trailers, []);
+
+console.log('Example: POST request with body:');
+
+parsed = parseRequest(
+  Buffer.from(`POST /memes HTTP/1.1
+Host: www.example.com
+Content-Length: 8
+Content-Type: text/plain
+
+your mom
+`)
+);
+
+console.log(parsed);
+
+deepStrictEqual(parsed.shouldKeepAlive, true);
+deepStrictEqual(parsed.upgrade, false);
+deepStrictEqual(parsed.method, 'POST');
+deepStrictEqual(parsed.url, '/memes');
+deepStrictEqual(parsed.versionMajor, 1);
+deepStrictEqual(parsed.versionMinor, 1);
+deepStrictEqual(parsed.headers, ['Host', 'www.example.com', 'Content-Length', '8', 'Content-Type', 'text/plain']);
+deepStrictEqual(parsed.body.toString(), 'your mom');
+deepStrictEqual(parsed.trailers, []);
+
+console.log('Example: basic HTML response');
+
+parsed = parseResponse(
+  Buffer.from(`HTTP/1.1 404 Not Found
+Content-Type: text/html
+Content-Length: 33
+
+<strong>Computer says no</strong>
+`)
+);
+
+console.log(parsed);
+
+deepStrictEqual(parsed.shouldKeepAlive, true);
+deepStrictEqual(parsed.upgrade, false);
+deepStrictEqual(parsed.statusCode, 404);
+deepStrictEqual(parsed.statusMessage, 'Not Found');
+deepStrictEqual(parsed.versionMajor, 1);
+deepStrictEqual(parsed.versionMinor, 1);
+deepStrictEqual(parsed.headers, ['Content-Type', 'text/html', 'Content-Length', '33']);
+deepStrictEqual(parsed.body.toString(), '<strong>Computer says no</strong>');
+deepStrictEqual(parsed.trailers, []);
+
+console.log('Example: chunked response with trailers');
+
+parsed = parseResponse(
+  Buffer.from(`HTTP/1.1 200 OK
+Content-Type: text/plain
+Transfer-Encoding: chunked
+Trailer: Expires
+
+7
+Mozilla
+9
+Developer
+7
+Network
+0
+Expires: Wed, 21 Oct 2015 07:28:00 GMT
+
+`)
+);
+
+console.log(parsed);
+
+deepStrictEqual(parsed.shouldKeepAlive, true);
+deepStrictEqual(parsed.upgrade, false);
+deepStrictEqual(parsed.statusCode, 200);
+deepStrictEqual(parsed.statusMessage, 'OK');
+deepStrictEqual(parsed.versionMajor, 1);
+deepStrictEqual(parsed.versionMinor, 1);
+deepStrictEqual(parsed.headers, ['Content-Type', 'text/plain', 'Transfer-Encoding', 'chunked', 'Trailer', 'Expires']);
+deepStrictEqual(parsed.body.toString(), 'MozillaDeveloperNetwork');
+deepStrictEqual(parsed.trailers, ['Expires', 'Wed, 21 Oct 2015 07:28:00 GMT']);


### PR DESCRIPTION
As discussed in https://github.com/creationix/http-parser-js/issues/88#issuecomment-1023615278 here's some examples how to use the library as a standalone parser. It also serves as a test, not sure if should be integrated into the test suite? At least when the parser needs to be adjusted again we can make sure the standalone usage works as expected by running the file. Or adjust it accordingly so that the file can always be used as a starting point.

One question: this runs in `compatMode0_12` because I don't access `kOnExecute`. It feels awkward to access the property just to trigger something and also it changes the `kOnHeadersComplete` arguments and I prefer getting the info object. But I don't have hard feelings, it works :shrug: 