### PR TITLE
Add maxHeaderSize to types

### DIFF
--- a/http-parser.d.ts
+++ b/http-parser.d.ts
@@ -92,6 +92,12 @@ declare class HTTPParserJS {
   [HTTPParser.kOnBody]: OnBodyParser
   [HTTPParser.kOnMessageComplete]: noop
 
+  /**
+   * Max number of bytes that will be parsed as headers, 80kb by default
+   * @default 81920
+   */
+  maxHeaderSize: number
+
   reinitialize: HTTPParserConstructor
   close: noop
   pause: noop


### PR DESCRIPTION
Adds the `.maxHeaderSize` field to the types of the `HTTPParserJS` class, otherwise tsc complains that the field doesn't exist.

Fixes this sort of thing:

```ts
const parser = new HTTPParser('RESPONSE')
parser.maxHeaderSize = 1024 * 1024
// error TS2339: Property 'maxHeaderSize' does not exist on type 'HTTPParserJS'
```